### PR TITLE
Addition of new fields

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,8 +25,8 @@ function getBookFromGoodreads() {
     book.abstract = document.getElementById("description").innerText;
     book.series = document.getElementById("bookSeries").innerText;
     book.rating = document.querySelector('[itemprop=ratingValue]').textContent;
-    book.rating_count=document.querySelector('[itemprop=ratingCount]').content
-    book.total_pages= document.querySelector('[itemprop=numberOfPages]').textContent
+    book.rating_count=document.querySelector('[itemprop=ratingCount]').content;
+    book.total_pages= document.querySelector('[itemprop=numberOfPages]').textContent;
 
     // Catch required as some books (such as test case) do not have this value
     try {

--- a/background.js
+++ b/background.js
@@ -24,6 +24,10 @@ function getBookFromGoodreads() {
     book.cover_image = `![](${book.cover_image_url})`;
     book.abstract = document.getElementById("description").innerText;
     book.series = document.getElementById("bookSeries").innerText;
+    book.rating = document.querySelector('[itemprop=ratingValue]').textContent;
+    book.rating_count=document.querySelector('[itemprop=ratingCount]').content
+    book.isbn13 = document.querySelector('[itemprop=isbn]').textContent
+    book.total_pages= document.querySelector('[itemprop=numberOfPages]').textContent
     return book;
 }
 

--- a/background.js
+++ b/background.js
@@ -26,8 +26,15 @@ function getBookFromGoodreads() {
     book.series = document.getElementById("bookSeries").innerText;
     book.rating = document.querySelector('[itemprop=ratingValue]').textContent;
     book.rating_count=document.querySelector('[itemprop=ratingCount]').content
-    book.isbn13 = document.querySelector('[itemprop=isbn]').textContent
     book.total_pages= document.querySelector('[itemprop=numberOfPages]').textContent
+
+    // Catch required as some books (such as test case) do not have this value
+    try {
+        book.isbn13 = document.querySelector('[itemprop=isbn]').textContent;
+    } 
+    catch (error) {
+        book.isbn13 = null
+    }
     return book;
 }
 

--- a/consts.js
+++ b/consts.js
@@ -30,6 +30,10 @@ export const DEFAULT_OPTIONS = {
         | **Full title** | {{ full_title }} |
         | **Authors** | {{ formatted_authors }} |
         | **Publication Year** | {{ publication_year }} |
+        | **Rating**| {{ rating }} |
+        | **No. of Ratings** | {{ rating_count }} |
+        | **No. of Pages** | {{ total_pages }} |
+        | **ISBN Number** | {{ isbn13 }} |
         | | |
     `),
 }

--- a/options.js
+++ b/options.js
@@ -11,11 +11,11 @@ function getFakeBook() {
     book.cover_image_url = "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1615552073l/12067.jpg";
     book.cover_image = `![](${book.cover_image_url})`;
     book.abstract = "‘Armageddon only happens once, you know. They don’t let you go around again until you get it right.’\nPeople have been predicting the end of the world almost from its very beginning, so it’s only natural to be sceptical when a new date is set for Judgement Day. But what if, for once, the predictions are right, and the apocalypse really is due to arrive next Saturday, just af ...more\n"
-    book.series = "Prophecies #3"
-    book.rating = "4.24"
-    book.rating_count = 620758
-    book.total_pages = "491 pages"
-    book.isbn13 = null
+    book.series = "Prophecies #3";
+    book.rating = "4.24";
+    book.rating_count = 620758;
+    book.total_pages = "491 pages";
+    book.isbn13 = null;
     return book;
 }
 

--- a/options.js
+++ b/options.js
@@ -12,6 +12,10 @@ function getFakeBook() {
     book.cover_image = `![](${book.cover_image_url})`;
     book.abstract = "‘Armageddon only happens once, you know. They don’t let you go around again until you get it right.’\nPeople have been predicting the end of the world almost from its very beginning, so it’s only natural to be sceptical when a new date is set for Judgement Day. But what if, for once, the predictions are right, and the apocalypse really is due to arrive next Saturday, just af ...more\n"
     book.series = "Prophecies #3"
+    book.rating = "4.24"
+    book.rating_count = 620758
+    book.total_pages = "491 pages"
+    book.isbn13 = null
     return book;
 }
 


### PR DESCRIPTION
Hi Nurdok,

Thanks for building this plugin, it's nice to finally be able to fill my obsidian library with everything not on kindle.

I've added a couple of fields that I like to look at so maybe others do too.
- rating (global book rating)
- rating_count (number of ratings the book has had)
- isbn13 (the ibsn 13 number, this also required a catch as I noticed your test case doesn't have an ibsn number attached)
- total_pages (number of pages the book has)

I have tested these as much as I can in the chrome dev tab as I'm not sure how to properly test chrome extensions) and they seem to work very well. There are a handful of others I was hoping to add too but mining the GoodReads page is interesting.

I've also tried to keep to your style, so please review.